### PR TITLE
fix: add Netlify configuration for Next.js deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
   command = "npm run build"
+  publish = ".next"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 [build]
   command = "npm run build"
-  publish = ".next"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- Add `netlify.toml` with build command and `@netlify/plugin-nextjs` plugin
- Remove empty `next.config.ts` to avoid conflict with `next.config.js`

## Problem
Netlify was showing "No build steps found" in the deploy log and deploying from `/` directly, resulting in a 404 page. This happened because there was no explicit build configuration.

## Solution
Added `netlify.toml` to explicitly configure:
- Build command: `npm run build`
- Publish directory: `.next`
- Next.js plugin for SSR/ISR support

## Test plan
- [ ] Merge to main and verify Netlify runs the build step
- [ ] Confirm site loads without 404 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)